### PR TITLE
payloads/external/skiboot/Makefile: remove DEBUG=1

### DIFF
--- a/payloads/external/skiboot/Makefile
+++ b/payloads/external/skiboot/Makefile
@@ -22,7 +22,7 @@ $(device_tree_blob): $(build_dir) $(device_tree_source)
 	dtc -I dts -O dtb -o $(device_tree_blob) $(device_tree_source)
 
 $(skiboot): $(skiboot_dir)
-	$(MAKE) -C $(skiboot_dir) -j`nproc` CROSS=powerpc64-linux-gnu- DEBUG=1
+	$(MAKE) -C $(skiboot_dir) -j`nproc` CROSS=powerpc64-linux-gnu-
 
 $(skiboot_dir):
 	git clone $(skiboot_git_repo) $(skiboot_dir)


### PR DESCRIPTION
Skiboot doesn't boot reliably with debug enabled - stucks on semaphore.

Signed-off-by: Krystian Hebel <krystian.hebel@3mdeb.com>
Change-Id: I267984f17928aaccc57bb31df2120ff5ce2d4dd2